### PR TITLE
Fix incorrect window title and size.

### DIFF
--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml
@@ -6,7 +6,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:controls="using:MrCapitalQ.FollowAlong.Controls"
-        mc:Ignorable="d">
+        mc:Ignorable="d"
+        Title="Follow Along">
     <Window.SystemBackdrop>
         <MicaBackdrop />
     </Window.SystemBackdrop>

--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml.cs
@@ -69,7 +69,7 @@ namespace MrCapitalQ.FollowAlong
 
             MainContent.Visibility = Visibility.Visible;
 
-            AppWindow.Resize(s_viewportWindowSize);
+            AppWindow.Resize(s_defaultWindowSize);
             this.CenterOnScreen();
             this.SetIsResizable(true);
             this.SetIsMinimizable(true);


### PR DESCRIPTION
Changes the default "WinUI Desktop" window title to "Follow Along" and fixes the window not restoring to current size after stopping screen capture.