### PR TITLE
Display thumbnail for monitor select list.

### DIFF
--- a/src/MrCapitalQ.FollowAlong.Core/Capture/BitmapCaptureService.cs
+++ b/src/MrCapitalQ.FollowAlong.Core/Capture/BitmapCaptureService.cs
@@ -58,7 +58,10 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
 
         public void StopCapture()
         {
-            _logger.LogInformation("Stopping capture session.");
+            var isStarted = IsStarted;
+
+            if (isStarted)
+                _logger.LogInformation("Stopping capture session.");
 
             IsStarted = false;
 
@@ -70,7 +73,8 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
             _framePool = null;
             _session?.Dispose();
 
-            OnStopped();
+            if (isStarted)
+                OnStopped();
         }
 
         public void RegisterFrameHandler(IBitmapFrameHandler handler)

--- a/src/MrCapitalQ.FollowAlong/Controls/CapturePreview.cs
+++ b/src/MrCapitalQ.FollowAlong/Controls/CapturePreview.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
 using MrCapitalQ.FollowAlong.Core.Capture;
 using MrCapitalQ.FollowAlong.Core.Tracking;
+using System;
 using System.Numerics;
 using Windows.Foundation;
 
@@ -55,13 +56,27 @@ namespace MrCapitalQ.FollowAlong.Controls
 
         public void Stop()
         {
-            using var session = CanvasComposition.CreateDrawingSession(_surface);
-            session.Clear(Colors.Transparent);
+            if (_surface is not null)
+            {
+                try
+                {
+                    using var session = CanvasComposition.CreateDrawingSession(_surface);
+                    session.Clear(Colors.Transparent);
+                }
+                catch (Exception ex) when (ex is ObjectDisposedException)
+                {
+                    _surface = null;
+                }
+            }
 
-            ElementCompositionPreview.SetElementChildVisual(this, null);
+            if (_visual is not null)
+            {
+                ElementCompositionPreview.SetElementChildVisual(this, null);
 
-            _visual?.Dispose();
-            _visual = null;
+                _visual?.Dispose();
+                _visual = null;
+            }
+
             _brush?.Dispose();
             _brush = null;
         }

--- a/src/MrCapitalQ.FollowAlong/Converters/AspectRatioConverter.cs
+++ b/src/MrCapitalQ.FollowAlong/Converters/AspectRatioConverter.cs
@@ -7,7 +7,7 @@ namespace MrCapitalQ.FollowAlong.Converters
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            if (!double.TryParse(value.ToString(), out var aspectRatio) || !double.TryParse(parameter.ToString(), out var height))
+            if (!double.TryParse(value?.ToString(), out var aspectRatio) || !double.TryParse(parameter?.ToString(), out var height))
                 return 0;
 
             return height * aspectRatio;

--- a/src/MrCapitalQ.FollowAlong/Converters/AspectRatioConverter.cs
+++ b/src/MrCapitalQ.FollowAlong/Converters/AspectRatioConverter.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.UI.Xaml.Data;
+using System;
+
+namespace MrCapitalQ.FollowAlong.Converters
+{
+    internal class AspectRatioConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if (!double.TryParse(value.ToString(), out var aspectRatio) || !double.TryParse(parameter.ToString(), out var height))
+                return 0;
+
+            return height * aspectRatio;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/MrCapitalQ.FollowAlong/MainViewModel.cs
+++ b/src/MrCapitalQ.FollowAlong/MainViewModel.cs
@@ -67,7 +67,7 @@ namespace MrCapitalQ.FollowAlong
         {
             using var bitmap = new Bitmap((int)MonitorInfo.MonitorArea.Width, (int)MonitorInfo.MonitorArea.Height);
             using var graphics = Graphics.FromImage(bitmap);
-            graphics.CopyFromScreen(0, 0, 0, 0, bitmap.Size);
+            graphics.CopyFromScreen((int)MonitorInfo.MonitorArea.Left, (int)MonitorInfo.MonitorArea.Top, 0, 0, bitmap.Size);
 
             using var memoryStream = new MemoryStream();
             bitmap.Save(memoryStream, ImageFormat.Png);

--- a/src/MrCapitalQ.FollowAlong/MainViewModel.cs
+++ b/src/MrCapitalQ.FollowAlong/MainViewModel.cs
@@ -12,10 +12,10 @@ namespace MrCapitalQ.FollowAlong
         private readonly BitmapCaptureService _captureService;
 
         [ObservableProperty]
-        private ObservableCollection<MonitorInfo> _monitors = new();
+        private ObservableCollection<MonitorViewModel> _monitors = new();
 
         [ObservableProperty]
-        private MonitorInfo? _selectedMonitor;
+        private MonitorViewModel? _selectedMonitor;
 
         public MainViewModel(MonitorService monitorService,
             HotKeysService hotKeysService,
@@ -23,8 +23,8 @@ namespace MrCapitalQ.FollowAlong
         {
             hotKeysService.HotKeyInvoked += HotKeysService_HotKeyInvoked;
 
-            Monitors = new(monitorService.GetAll());
-            SelectedMonitor = Monitors.FirstOrDefault(x => x.IsPrimary);
+            Monitors = new(monitorService.GetAll().Select(x => new MonitorViewModel(x)));
+            SelectedMonitor = Monitors.FirstOrDefault(x => x.MonitorInfo.IsPrimary);
             _captureService = captureService;
         }
 
@@ -33,13 +33,24 @@ namespace MrCapitalQ.FollowAlong
             if (e.HotKeyType != HotKeyType.StartStop)
                 return;
 
-                if (!_captureService.IsStarted && SelectedMonitor is not null)
-                {
-                    var captureItem = SelectedMonitor.CreateCaptureItem();
-                    _captureService.StartCapture(captureItem);
-                }
-                else if (_captureService.IsStarted)
-                    _captureService.StopCapture();
+            if (!_captureService.IsStarted && SelectedMonitor is not null)
+            {
+                var captureItem = SelectedMonitor.MonitorInfo.CreateCaptureItem();
+                _captureService.StartCapture(captureItem);
             }
+            else if (_captureService.IsStarted)
+                _captureService.StopCapture();
+        }
+    }
+
+    internal class MonitorViewModel
+    {
+        public MonitorViewModel(MonitorInfo monitorInfo)
+        {
+            MonitorInfo = monitorInfo;
+        }
+
+        public MonitorInfo MonitorInfo { get; }
+        public double AspectRatio => MonitorInfo.ScreenSize.X / MonitorInfo.ScreenSize.Y;
     }
 }

--- a/src/MrCapitalQ.FollowAlong/MainViewModel.cs
+++ b/src/MrCapitalQ.FollowAlong/MainViewModel.cs
@@ -1,9 +1,15 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.UI.Xaml.Media.Imaging;
 using MrCapitalQ.FollowAlong.Core.Capture;
 using MrCapitalQ.FollowAlong.Core.HotKeys;
 using MrCapitalQ.FollowAlong.Core.Monitors;
+using System;
 using System.Collections.ObjectModel;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace MrCapitalQ.FollowAlong
 {
@@ -48,9 +54,26 @@ namespace MrCapitalQ.FollowAlong
         public MonitorViewModel(MonitorInfo monitorInfo)
         {
             MonitorInfo = monitorInfo;
+            BitmapImage = new();
+
+            _ = LoadThumbnailAsync();
         }
 
         public MonitorInfo MonitorInfo { get; }
+        public BitmapImage BitmapImage { get; }
         public double AspectRatio => MonitorInfo.ScreenSize.X / MonitorInfo.ScreenSize.Y;
+
+        private async Task LoadThumbnailAsync()
+        {
+            using var bitmap = new Bitmap((int)MonitorInfo.MonitorArea.Width, (int)MonitorInfo.MonitorArea.Height);
+            using var graphics = Graphics.FromImage(bitmap);
+            graphics.CopyFromScreen(0, 0, 0, 0, bitmap.Size);
+
+            using var memoryStream = new MemoryStream();
+            bitmap.Save(memoryStream, ImageFormat.Png);
+            memoryStream.Position = 0;
+
+            await BitmapImage.SetSourceAsync(memoryStream.AsRandomAccessStream());
+        }
     }
 }

--- a/src/MrCapitalQ.FollowAlong/MainViewModel.cs
+++ b/src/MrCapitalQ.FollowAlong/MainViewModel.cs
@@ -65,14 +65,17 @@ namespace MrCapitalQ.FollowAlong
 
         private async Task LoadThumbnailAsync()
         {
-            using var bitmap = new Bitmap((int)MonitorInfo.MonitorArea.Width, (int)MonitorInfo.MonitorArea.Height);
-            using var graphics = Graphics.FromImage(bitmap);
-            graphics.CopyFromScreen((int)MonitorInfo.MonitorArea.Left, (int)MonitorInfo.MonitorArea.Top, 0, 0, bitmap.Size);
+            using var memoryStream = await Task.Run(() =>
+            {
+                using var bitmap = new Bitmap((int)MonitorInfo.MonitorArea.Width, (int)MonitorInfo.MonitorArea.Height);
+                using var graphics = Graphics.FromImage(bitmap);
+                graphics.CopyFromScreen((int)MonitorInfo.MonitorArea.Left, (int)MonitorInfo.MonitorArea.Top, 0, 0, bitmap.Size);
 
-            using var memoryStream = new MemoryStream();
-            bitmap.Save(memoryStream, ImageFormat.Png);
-            memoryStream.Position = 0;
-
+                var memoryStream = new MemoryStream();
+                bitmap.Save(memoryStream, ImageFormat.Png);
+                memoryStream.Position = 0;
+                return memoryStream;
+            });
             await BitmapImage.SetSourceAsync(memoryStream.AsRandomAccessStream());
         }
     }

--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml
@@ -13,8 +13,7 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <Grid x:Name="Root"
-          HorizontalAlignment="Stretch"
+    <Grid HorizontalAlignment="Stretch"
           VerticalAlignment="Stretch">
         <Grid.Resources>
             <converters:AspectRatioConverter x:Key="AspectRatioConverter" />

--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml
@@ -29,7 +29,7 @@
             <StackPanel x:Name="MainContent"
                         VerticalAlignment="Center">
                 <GridView ItemsSource="{x:Bind _viewModel.Monitors}"
-                          SelectedItem="{x:Bind _viewModel.SelectedMonitor}"
+                          SelectedItem="{x:Bind _viewModel.SelectedMonitor, Mode=TwoWay}"
                           SelectionMode="Single"
                           Padding="32,8"
                           ScrollViewer.HorizontalScrollMode="Enabled"
@@ -43,13 +43,13 @@
                     </GridView.ItemsPanel>
                     <GridView.ItemTemplate>
                         <DataTemplate x:DataType="local:MonitorViewModel">
-                            <Border Height="120"
-                                    Width="{Binding AspectRatio, Converter={StaticResource AspectRatioConverter}, ConverterParameter=120}"
-                                    BorderBrush="Black"
+                            <Border BorderBrush="Black"
                                     BorderThickness="4"
                                     CornerRadius="4"
                                     Margin="4">
-                                <Image Source="{Binding BitmapImage, Mode=OneWay}" />
+                                <Image Source="{Binding BitmapImage, Mode=OneWay}"
+                                       Height="120"
+                                       Width="{Binding AspectRatio, Converter={StaticResource AspectRatioConverter}, ConverterParameter=120}" />
                             </Border>
                         </DataTemplate>
                     </GridView.ItemTemplate>

--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:controls="using:MrCapitalQ.FollowAlong.Controls"
-        xmlns:monitors="using:MrCapitalQ.FollowAlong.Core.Monitors"
+        xmlns:converters="using:MrCapitalQ.FollowAlong.Converters"
         mc:Ignorable="d"
         Title="Follow Along">
     <Window.SystemBackdrop>
@@ -16,30 +16,49 @@
     <Grid x:Name="Root"
           HorizontalAlignment="Stretch"
           VerticalAlignment="Stretch">
+        <Grid.Resources>
+            <converters:AspectRatioConverter x:Key="AspectRatioConverter" />
+        </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="32" />
             <RowDefinition />
         </Grid.RowDefinitions>
         <controls:CapturePreview x:Name="Preview"
                                  Grid.RowSpan="2" />
-        <StackPanel x:Name="MainContent"
-                    Margin="16"
-                    VerticalAlignment="Center"
-                    Grid.Row="1">
-            <ListView ItemsSource="{x:Bind _viewModel.Monitors}"
-                      SelectedItem="{x:Bind _viewModel.SelectedMonitor}"
-                      SelectionMode="Single"
-                      Grid.Row="1">
-                <ListView.ItemTemplate>
-                    <DataTemplate x:DataType="monitors:MonitorInfo">
-                        <TextBlock Text="{x:Bind DeviceName}" />
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
-            <TextBlock TextWrapping="Wrap"
-                       TextAlignment="Center">Press Ctrl + Shift + Alt + S to start or stop.</TextBlock>
-            <TextBlock TextWrapping="Wrap"
-                       TextAlignment="Center">When starting, this window will be hidden and will be restored after stopping.</TextBlock>
-        </StackPanel>
+        <ScrollViewer Grid.Row="1">
+            <StackPanel x:Name="MainContent"
+                        VerticalAlignment="Center">
+                <GridView ItemsSource="{x:Bind _viewModel.Monitors}"
+                          SelectedItem="{x:Bind _viewModel.SelectedMonitor}"
+                          SelectionMode="Single"
+                          Padding="32,8"
+                          ScrollViewer.HorizontalScrollMode="Enabled"
+                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                          ScrollViewer.VerticalScrollMode="Disabled">
+                    <GridView.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <ItemsStackPanel Orientation="Horizontal"
+                                             HorizontalAlignment="Center" />
+                        </ItemsPanelTemplate>
+                    </GridView.ItemsPanel>
+                    <GridView.ItemTemplate>
+                        <DataTemplate x:DataType="local:MonitorViewModel">
+                            <Border Height="120"
+                                    Width="{Binding AspectRatio, Converter={StaticResource AspectRatioConverter}, ConverterParameter=120}"
+                                    BorderBrush="Black"
+                                    BorderThickness="4"
+                                    CornerRadius="4"
+                                    Margin="4">
+                                <ContentPresenter Background="Green" />
+                            </Border>
+                        </DataTemplate>
+                    </GridView.ItemTemplate>
+                </GridView>
+                <TextBlock TextWrapping="Wrap"
+                           TextAlignment="Center">Press Ctrl + Shift + Alt + S to start or stop.</TextBlock>
+                <TextBlock TextWrapping="Wrap"
+                           TextAlignment="Center">When starting, this window will be hidden and will be restored after stopping.</TextBlock>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </Window>

--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml
@@ -49,7 +49,7 @@
                                     BorderThickness="4"
                                     CornerRadius="4"
                                     Margin="4">
-                                <ContentPresenter Background="Green" />
+                                <Image Source="{Binding BitmapImage, Mode=OneWay}" />
                             </Border>
                         </DataTemplate>
                     </GridView.ItemTemplate>

--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml.cs
@@ -15,7 +15,7 @@ namespace MrCapitalQ.FollowAlong
         private const double MaxZoom = 3;
         private const double MinZoom = 1;
         private const double ZoomStepSize = 0.5;
-        private readonly static SizeInt32 s_defaultWindowSize = new(640, 480);
+        private readonly static SizeInt32 s_defaultWindowSize = new(800, 600);
         private readonly static SizeInt32 s_viewportWindowSize = new(1280, 720);
 
         private readonly TrackingTransformService _trackingTransformService;

--- a/src/MrCapitalQ.FollowAlong/MrCapitalQ.FollowAlong.csproj
+++ b/src/MrCapitalQ.FollowAlong/MrCapitalQ.FollowAlong.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
   


### PR DESCRIPTION
Update the main window's list of available monitors to show a thumbnail of the monitor. This will more useful when selecting a monitor by visually seeing the content of each monitor's screen rather than a non-descriptive system monitor name.