### PR TITLE
Display preview window.

### DIFF
--- a/src/MrCapitalQ.FollowAlong.Core/Capture/BitmapCaptureService.cs
+++ b/src/MrCapitalQ.FollowAlong.Core/Capture/BitmapCaptureService.cs
@@ -93,6 +93,12 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
                 handler.Initialize(_canvasDevice, new Size(_captureItem.Size.Width, _captureItem.Size.Height));
         }
 
+        public void UnregisterFrameHandler(IBitmapFrameHandler handler)
+        {
+            _handlers.Remove(handler);
+            handler.Stop();
+        }
+
         public void Dispose() => StopCapture();
 
         private void OnStarted()

--- a/src/MrCapitalQ.FollowAlong.Core/Capture/BitmapCaptureService.cs
+++ b/src/MrCapitalQ.FollowAlong.Core/Capture/BitmapCaptureService.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Graphics.Canvas;
 using System;
+using System.Collections.Generic;
 using Windows.Foundation;
 using Windows.Graphics;
 using Windows.Graphics.Capture;
@@ -14,7 +15,8 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
         public event EventHandler? Stopped;
 
         private readonly ILogger<BitmapCaptureService> _logger;
-        private IBitmapFrameHandler? _handler;
+        private readonly HashSet<IBitmapFrameHandler> _handlers = new();
+        private GraphicsCaptureItem? _captureItem;
         private CanvasDevice? _canvasDevice;
         private Direct3D11CaptureFramePool? _framePool;
         private GraphicsCaptureSession? _session;
@@ -32,15 +34,16 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
             if (IsStarted)
                 throw new InvalidOperationException("Cannot start capture because a capture is has already been started.");
 
-            if (_handler is null)
-                throw new InvalidOperationException("A bitmap frame handler must be registered before starting.");
-
             _logger.LogInformation("Starting capture session of {CaptureItemDisplayName}.", captureItem.DisplayName);
 
             IsStarted = true;
+            _captureItem = captureItem;
 
             _canvasDevice = new CanvasDevice();
-            _handler.Initialize(_canvasDevice, new Size(captureItem.Size.Width, captureItem.Size.Height));
+            foreach (var handler in _handlers)
+            {
+                handler.Initialize(_canvasDevice, new Size(captureItem.Size.Width, captureItem.Size.Height));
+            }
 
             _framePool = Direct3D11CaptureFramePool.Create(_canvasDevice,
                 DirectXPixelFormat.B8G8R8A8UIntNormalized,
@@ -65,13 +68,18 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
 
             IsStarted = false;
 
-            _handler?.Stop();
+            foreach (var handler in _handlers)
+            {
+                handler.Stop();
+            }
 
             _canvasDevice?.Dispose();
             _canvasDevice = null;
             _framePool?.Dispose();
             _framePool = null;
             _session?.Dispose();
+            _session = null;
+            _captureItem = null;
 
             if (isStarted)
                 OnStopped();
@@ -79,13 +87,10 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
 
         public void RegisterFrameHandler(IBitmapFrameHandler handler)
         {
-            if (_handler is not null)
-                throw new InvalidOperationException("A bitmap frame handler has already been set.");
+            _handlers.Add(handler);
 
-            if (IsStarted)
-                throw new InvalidOperationException("A bitmap frame handler cannot be registered after starting.");
-
-            _handler = handler;
+            if (IsStarted && _captureItem is not null && _canvasDevice is not null)
+                handler.Initialize(_canvasDevice, new Size(_captureItem.Size.Width, _captureItem.Size.Height));
         }
 
         public void Dispose() => StopCapture();
@@ -119,7 +124,10 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
             try
             {
                 var canvasBitmap = CanvasBitmap.CreateFromDirect3D11Surface(_canvasDevice, frame.Surface);
-                _handler?.HandleFrame(canvasBitmap);
+                foreach (var handler in _handlers)
+                {
+                    handler.HandleFrame(canvasBitmap);
+                }
             }
             catch (Exception ex) when (_canvasDevice?.IsDeviceLost(ex.HResult) != false)
             {
@@ -146,8 +154,10 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
                     if (recreateDevice)
                     {
                         _canvasDevice = new CanvasDevice();
-
-                        _handler?.Initialize(_canvasDevice);
+                        foreach (var handler in _handlers)
+                        {
+                            handler.Initialize(_canvasDevice);
+                        };
                     }
 
                     _framePool?.Recreate(_canvasDevice,

--- a/src/MrCapitalQ.FollowAlong.Core/Utils/WindowExtensions.cs
+++ b/src/MrCapitalQ.FollowAlong.Core/Utils/WindowExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.UI.Xaml;
+using System;
+using System.Runtime.InteropServices;
+
+namespace MrCapitalQ.FollowAlong.Core.Utils
+{
+    public static class WindowExtensions
+    {
+        const uint WDA_EXCLUDEFROMCAPTURE = 0x00000011;
+
+        [DllImport("user32.dll")]
+        private static extern uint SetWindowDisplayAffinity(IntPtr hwnd, uint dwAffinity);
+
+        public static void ExcludeFromCapture(this Window window)
+        {
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+            _ = SetWindowDisplayAffinity(hWnd, WDA_EXCLUDEFROMCAPTURE);
+        }
+    }
+}

--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml
@@ -30,7 +30,7 @@
                 <GridView ItemsSource="{x:Bind _viewModel.Monitors}"
                           SelectedItem="{x:Bind _viewModel.SelectedMonitor, Mode=TwoWay}"
                           SelectionMode="Single"
-                          Padding="32,8"
+                          Padding="32,16"
                           ScrollViewer.HorizontalScrollMode="Enabled"
                           ScrollViewer.HorizontalScrollBarVisibility="Auto"
                           ScrollViewer.VerticalScrollMode="Disabled">
@@ -53,10 +53,44 @@
                         </DataTemplate>
                     </GridView.ItemTemplate>
                 </GridView>
-                <TextBlock TextWrapping="Wrap"
-                           TextAlignment="Center">Press Ctrl + Shift + Alt + S to start or stop.</TextBlock>
-                <TextBlock TextWrapping="Wrap"
-                           TextAlignment="Center">When starting, this window will be hidden and will be restored after stopping.</TextBlock>
+                <Grid ColumnSpacing="16"
+                      RowSpacing="4"
+                      HorizontalAlignment="Center">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <TextBlock Text="Start/Stop"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    <TextBlock TextWrapping="Wrap"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Grid.Column="1">
+                            Ctrl + Shift + Alt + S
+                    </TextBlock>
+                    <TextBlock Text="Zoom in"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Grid.Row="1" />
+                    <TextBlock TextWrapping="Wrap"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Grid.Column="1"
+                               Grid.Row="1">
+                        Ctrl + Shift + Alt + Plus
+                    </TextBlock>
+                    <TextBlock Text="Zoom out"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Grid.Row="2" />
+                    <TextBlock TextWrapping="Wrap"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               Grid.Column="1"
+                               Grid.Row="2">
+                        Ctrl + Shift + Alt + Minus
+                    </TextBlock>
+                </Grid>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml.cs
@@ -83,7 +83,12 @@ namespace MrCapitalQ.FollowAlong
             this.SetIsMaximizable(true);
             this.SetForegroundWindow();
 
-            _previewWindow?.Hide();
+            if (_previewWindow is not null)
+            {
+                _previewWindow.Closed -= PreviewWindow_Closed;
+                _previewWindow.Close();
+                _previewWindow = null;
+            }
         }
 
         private void HotKeysService_HotKeyInvoked(object? sender, HotKeyInvokedEventArgs e)

--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
@@ -13,9 +14,6 @@ namespace MrCapitalQ.FollowAlong
 {
     internal sealed partial class MainWindow : Window
     {
-        private const double MaxZoom = 3;
-        private const double MinZoom = 1;
-        private const double ZoomStepSize = 0.5;
         private readonly static SizeInt32 s_defaultWindowSize = new(800, 600);
         private readonly static SizeInt32 s_viewportWindowSize = new(1280, 720);
 
@@ -35,13 +33,13 @@ namespace MrCapitalQ.FollowAlong
             captureService.Stopped += CaptureService_Stopped;
 
             _trackingTransformService = trackingTransformService;
-            _trackingTransformService.Zoom = 1.5;
             _trackingTransformService.StartTrackingTransforms(Preview);
-
-            _viewModel = viewModel;
+            WeakReferenceMessenger.Default.Register<ZoomChanged>(this,
+                (r, m) => _trackingTransformService.Zoom = m.Zoom);
 
             hotKeysService.RegisterHotKeys(this);
-            hotKeysService.HotKeyInvoked += HotKeysService_HotKeyInvoked;
+
+            _viewModel = viewModel;
 
             ExtendsContentIntoTitleBar = true;
             AppWindow.Resize(s_defaultWindowSize);
@@ -89,14 +87,6 @@ namespace MrCapitalQ.FollowAlong
                 _previewWindow.Close();
                 _previewWindow = null;
             }
-        }
-
-        private void HotKeysService_HotKeyInvoked(object? sender, HotKeyInvokedEventArgs e)
-        {
-            if (e.HotKeyType == HotKeyType.ZoomIn)
-                _trackingTransformService.Zoom = Math.Min(_trackingTransformService.Zoom + ZoomStepSize, MaxZoom);
-            else if (e.HotKeyType == HotKeyType.ZoomOut)
-                _trackingTransformService.Zoom = Math.Max(_trackingTransformService.Zoom - ZoomStepSize, MinZoom);
         }
 
         private void MainWindow_Closed(object sender, WindowEventArgs args) => _previewWindow?.Close();

--- a/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml
+++ b/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window x:Class="MrCapitalQ.FollowAlong.PreviewWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="using:MrCapitalQ.FollowAlong"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d">
+
+    <Grid>
+
+    </Grid>
+</Window>

--- a/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml
+++ b/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml
@@ -5,9 +5,10 @@
         xmlns:local="using:MrCapitalQ.FollowAlong"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:controls="using:MrCapitalQ.FollowAlong.Controls"
         mc:Ignorable="d">
 
-    <Grid>
-
+    <Grid x:Name="Root">
+        <controls:CapturePreview x:Name="Preview" />
     </Grid>
 </Window>

--- a/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml.cs
@@ -13,6 +13,7 @@ namespace MrCapitalQ.FollowAlong
     {
         private const int BottomPadding = 48;
         private readonly static SizeInt32 s_windowSize = new(480, 320);
+        private readonly BitmapCaptureService _captureService;
         private readonly TrackingTransformService _trackingTransformService;
 
         public PreviewWindow(BitmapCaptureService captureService,
@@ -20,7 +21,8 @@ namespace MrCapitalQ.FollowAlong
         {
             InitializeComponent();
 
-            captureService.RegisterFrameHandler(Preview);
+            _captureService = captureService;
+            _captureService.RegisterFrameHandler(Preview);
 
             _trackingTransformService = trackingTransformService;
             _trackingTransformService.StartTrackingTransforms(Preview);
@@ -61,6 +63,7 @@ namespace MrCapitalQ.FollowAlong
             Root.Loaded -= Root_Loaded;
             Activated -= PreviewWindow_Activated;
             Closed -= PreviewWindow_Closed;
+            _captureService.UnregisterFrameHandler(Preview);
             _trackingTransformService.StopTrackingTransforms();
             WeakReferenceMessenger.Default.UnregisterAll(this);
         }

--- a/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.UI.Xaml;
 using MrCapitalQ.FollowAlong.Core.Capture;
 using MrCapitalQ.FollowAlong.Core.Monitors;
@@ -23,8 +24,9 @@ namespace MrCapitalQ.FollowAlong
             captureService.RegisterFrameHandler(Preview);
 
             _trackingTransformService = trackingTransformService;
-            _trackingTransformService.Zoom = 1.5;
             _trackingTransformService.StartTrackingTransforms(Preview);
+            WeakReferenceMessenger.Default.Register<ZoomChanged>(this,
+                (r, m) => _trackingTransformService.Zoom = m.Zoom);
 
             ExcludeWindowFromCapture();
             this.SetIsShownInSwitchers(false);

--- a/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml.cs
@@ -1,5 +1,9 @@
 using Microsoft.UI.Xaml;
+using MrCapitalQ.FollowAlong.Core.Capture;
 using MrCapitalQ.FollowAlong.Core.Monitors;
+using MrCapitalQ.FollowAlong.Core.Tracking;
+using System;
+using System.Runtime.InteropServices;
 using Windows.Graphics;
 using WinUIEx;
 
@@ -7,12 +11,22 @@ namespace MrCapitalQ.FollowAlong
 {
     public sealed partial class PreviewWindow : Window
     {
+        private const int BottomPadding = 48;
         private readonly static SizeInt32 s_windowSize = new(480, 320);
+        private readonly TrackingTransformService _trackingTransformService;
 
-        public PreviewWindow()
+        public PreviewWindow(BitmapCaptureService captureService,
+            TrackingTransformService trackingTransformService)
         {
             InitializeComponent();
 
+            captureService.RegisterFrameHandler(Preview);
+
+            _trackingTransformService = trackingTransformService;
+            _trackingTransformService.Zoom = 1.5;
+            _trackingTransformService.StartTrackingTransforms(Preview);
+
+            ExcludeWindowFromCapture();
             this.SetIsShownInSwitchers(false);
             this.SetIsResizable(false);
             this.SetIsMinimizable(false);
@@ -21,10 +35,34 @@ namespace MrCapitalQ.FollowAlong
 
             ExtendsContentIntoTitleBar = true;
             AppWindow.Resize(s_windowSize);
+            RepositionToPreviewPosition();
 
+            Root.Loaded += Root_Loaded;
+            Activated += PreviewWindow_Activated;
+        }
+
+        private void RepositionToPreviewPosition()
+        {
             var appMonitor = this.GetWindowMonitorSize();
             if (appMonitor is not null)
-                AppWindow.Move(new PointInt32((int)appMonitor.ScreenSize.X - s_windowSize.Width, (int)appMonitor.ScreenSize.Y - s_windowSize.Height));
+                AppWindow.Move(new PointInt32(0,
+                    (int)(appMonitor.ScreenSize.Y - s_windowSize.Height - (BottomPadding * Root.XamlRoot?.RasterizationScale ?? 1))));
+        }
+
+        private void Root_Loaded(object sender, RoutedEventArgs e) => RepositionToPreviewPosition();
+
+        private void PreviewWindow_Activated(object sender, WindowActivatedEventArgs args)
+            => _trackingTransformService.UpdateLayout();
+
+        [DllImport("user32.dll")]
+        private static extern uint SetWindowDisplayAffinity(IntPtr hwnd, uint dwAffinity);
+
+        private void ExcludeWindowFromCapture()
+        {
+            const uint WDA_EXCLUDEFROMCAPTURE = 0x00000011;
+
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            _ = SetWindowDisplayAffinity(hWnd, WDA_EXCLUDEFROMCAPTURE);
         }
     }
 }

--- a/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/PreviewWindow.xaml.cs
@@ -1,0 +1,30 @@
+using Microsoft.UI.Xaml;
+using MrCapitalQ.FollowAlong.Core.Monitors;
+using Windows.Graphics;
+using WinUIEx;
+
+namespace MrCapitalQ.FollowAlong
+{
+    public sealed partial class PreviewWindow : Window
+    {
+        private readonly static SizeInt32 s_windowSize = new(480, 320);
+
+        public PreviewWindow()
+        {
+            InitializeComponent();
+
+            this.SetIsShownInSwitchers(false);
+            this.SetIsResizable(false);
+            this.SetIsMinimizable(false);
+            this.SetIsMaximizable(false);
+            this.SetIsAlwaysOnTop(true);
+
+            ExtendsContentIntoTitleBar = true;
+            AppWindow.Resize(s_windowSize);
+
+            var appMonitor = this.GetWindowMonitorSize();
+            if (appMonitor is not null)
+                AppWindow.Move(new PointInt32((int)appMonitor.ScreenSize.X - s_windowSize.Width, (int)appMonitor.ScreenSize.Y - s_windowSize.Height));
+        }
+    }
+}

--- a/src/MrCapitalQ.FollowAlong/Program.cs
+++ b/src/MrCapitalQ.FollowAlong/Program.cs
@@ -22,13 +22,15 @@ Host.CreateDefaultBuilder(args)
         services.AddHostedService<WinUIHostedService<App>>();
         services.AddSingleton<App>();
         services.AddSingleton<MainWindow>();
+        services.AddTransient<PreviewWindow>();
+
+        services.AddSingleton<MainViewModel>();
 
         services.AddTransient<MonitorService>();
         services.AddSingleton<BitmapCaptureService>();
         services.AddTransient<PointerService>();
         services.AddTransient<TrackingTransformService>();
         services.AddSingleton<HotKeysService>();
-        services.AddTransient<MainViewModel>();
     })
     .Build()
     .Run();

--- a/src/MrCapitalQ.FollowAlong/ZoomChanged.cs
+++ b/src/MrCapitalQ.FollowAlong/ZoomChanged.cs
@@ -1,0 +1,4 @@
+﻿namespace MrCapitalQ.FollowAlong
+{
+    public record ZoomChanged(double Zoom);
+}


### PR DESCRIPTION
When starting a session, show a preview of zoomed screen content is so the user can position the mouse correctly when sharing. The preview window is not captured and only visible to the presenter. Stopping a session will close the preview window.