### PR TITLE
Make sharing window visible is switchers.

### DIFF
--- a/src/MrCapitalQ.FollowAlong.Core/Capture/BitmapCaptureService.cs
+++ b/src/MrCapitalQ.FollowAlong.Core/Capture/BitmapCaptureService.cs
@@ -14,6 +14,8 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
         public event EventHandler<CaptureStartedEventArgs>? Started;
         public event EventHandler? Stopped;
 
+        private const double FrameRate = 30;
+
         private readonly ILogger<BitmapCaptureService> _logger;
         private readonly HashSet<IBitmapFrameHandler> _handlers = new();
         private GraphicsCaptureItem? _captureItem;
@@ -21,6 +23,7 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
         private Direct3D11CaptureFramePool? _framePool;
         private GraphicsCaptureSession? _session;
         private SizeInt32 _lastSize;
+        private DateTime _nextFrameTime;
 
         public BitmapCaptureService(ILogger<BitmapCaptureService> logger)
         {
@@ -118,8 +121,10 @@ namespace MrCapitalQ.FollowAlong.Core.Capture
             var needsReset = false;
 
             using var frame = sender.TryGetNextFrame();
-            if (frame is null)
+            if (frame is null || DateTime.Now < _nextFrameTime)
                 return;
+
+            _nextFrameTime = DateTime.Now.AddSeconds(1 / FrameRate);
 
             if (frame.ContentSize.Width != _lastSize.Width || frame.ContentSize.Height != _lastSize.Height)
             {

--- a/src/MrCapitalQ.FollowAlong/ShareWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/ShareWindow.xaml.cs
@@ -1,10 +1,10 @@
 using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using MrCapitalQ.FollowAlong.Core.Capture;
 using MrCapitalQ.FollowAlong.Core.Monitors;
 using MrCapitalQ.FollowAlong.Core.Tracking;
 using Windows.Graphics;
-using WinUIEx;
 
 namespace MrCapitalQ.FollowAlong
 {
@@ -28,10 +28,13 @@ namespace MrCapitalQ.FollowAlong
             WeakReferenceMessenger.Default.Register<ZoomChanged>(this,
                 (r, m) => _trackingTransformService.Zoom = m.Zoom);
 
-            this.SetIsShownInSwitchers(false);
-            this.SetIsResizable(false);
-            this.SetIsMinimizable(false);
-            this.SetIsMaximizable(false);
+            if (AppWindow.Presenter is OverlappedPresenter presenter)
+            {
+                presenter.IsResizable = false;
+                presenter.IsMinimizable = false;
+                presenter.IsMaximizable = false;
+                presenter.SetBorderAndTitleBar(false, false);
+            }
 
             ExtendsContentIntoTitleBar = true;
             RepositionToSharingPosition();


### PR DESCRIPTION
Fix sharing window not having visible content when sharing in Teams by having it visible in switchers again. Also limit frame rate to 30 fps by default.