### PR TITLE
Position preview window based on monitor work area.

### DIFF
--- a/src/MrCapitalQ.FollowAlong.Core/Monitors/MonitorExtensions.cs
+++ b/src/MrCapitalQ.FollowAlong.Core/Monitors/MonitorExtensions.cs
@@ -19,7 +19,7 @@ namespace MrCapitalQ.FollowAlong.Core.Monitors
             return item;
         }
 
-        public static MonitorInfo? GetWindowMonitorSize(this Window window)
+        public static MonitorInfo? GetCurrentMonitorInfo(this Window window)
         {
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
             return MonitorInterops.GetMonitorFromWindow(hwnd);

--- a/src/MrCapitalQ.FollowAlong/MainWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/MainWindow.xaml.cs
@@ -16,7 +16,6 @@ namespace MrCapitalQ.FollowAlong
 {
     internal sealed partial class MainWindow : WindowEx
     {
-        private const int BottomPadding = 48;
         private readonly static SizeInt32 s_minWindowSize = new(600, 450);
         private readonly static SizeInt32 s_previewWindowSize = new(384, 216);
 
@@ -73,15 +72,13 @@ namespace MrCapitalQ.FollowAlong
             MinHeight = 0;
             this.SetIsExcludedFromCapture(true);
 
-            var scale = Root.XamlRoot?.RasterizationScale ?? 1;
-
             Width = s_previewWindowSize.Width;
             Height = s_previewWindowSize.Height;
 
-            var appMonitor = this.GetWindowMonitorSize();
-            if (appMonitor is not null)
-                AppWindow.Move(new PointInt32(0,
-                    (int)(appMonitor.ScreenSize.Y - (s_previewWindowSize.Height * scale) - (BottomPadding * scale))));
+            var monitorInfo = this.GetCurrentMonitorInfo();
+            if (monitorInfo is not null)
+                AppWindow.Move(new PointInt32((int)(monitorInfo.WorkArea.Left),
+                    (int)(monitorInfo.WorkArea.Bottom - AppWindow.Size.Height)));
         }
 
         private void CaptureService_Started(object? sender, CaptureStartedEventArgs e)

--- a/src/MrCapitalQ.FollowAlong/ShareWindow.xaml.cs
+++ b/src/MrCapitalQ.FollowAlong/ShareWindow.xaml.cs
@@ -54,7 +54,7 @@ namespace MrCapitalQ.FollowAlong
 
         private void RepositionToSharingPosition()
         {
-            var appMonitor = this.GetWindowMonitorSize();
+            var appMonitor = this.GetCurrentMonitorInfo();
             if (appMonitor is not null)
                 AppWindow.Move(new PointInt32((int)appMonitor.ScreenSize.X - 1, (int)appMonitor.ScreenSize.Y - 1));
         }


### PR DESCRIPTION
Use the monitor's work area info to correctly place the preview window in the corner of the current screen accounting for task bar position and size.