### PR TITLE
Include content-type header when updating variables.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -244,6 +244,7 @@ jobs:
         $variableUrl = "https://api.github.com/repos/${{ github.repository }}/environments/$($env:ENVIRONMENT_NAME)/variables/$variableName"
         $headers = @{
             "Accept" = "application/vnd.github+json"
+            "Content-Type" = "application/json"
             "Authorization" = "Bearer $env:ACCESS_TOKEN"
             "X-GitHub-Api-Version" = "2022-11-28"
         }


### PR DESCRIPTION
Updating a variable using GitHub's REST API now throws the error "The given key 'Content-Type' was not present in the dictionary." in PowerShell. Fixing by including this header.