### PR TITLE
Create GraphicsCaptureItem without interops.

### DIFF
--- a/src/MrCapitalQ.FollowAlong.Core/Display/DisplayExtensions.cs
+++ b/src/MrCapitalQ.FollowAlong.Core/Display/DisplayExtensions.cs
@@ -1,28 +1,13 @@
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
-using Windows.Graphics.Capture;
 
 namespace MrCapitalQ.FollowAlong.Core.Display
 {
-    [ExcludeFromCodeCoverage(Justification = "Native interops.")]
+    [ExcludeFromCodeCoverage(Justification = "Uses native static APIs that can't be mocked.")]
     public static class DisplayExtensions
     {
-        private static readonly Guid s_graphicsCaptureItemGuid = new("79C3F95B-31F7-4EC2-A464-632EF5D30760");
-
-        public static GraphicsCaptureItem CreateCaptureItem(this DisplayItem displayItem)
-        {
-            var interop = GraphicsCaptureItem.As<IGraphicsCaptureItemInterop>();
-            var itemPointer = interop.CreateForMonitor((nint)displayItem.DisplayId, s_graphicsCaptureItemGuid);
-            var item = GraphicsCaptureItem.FromAbi(itemPointer);
-            Marshal.Release(itemPointer);
-
-            return item;
-        }
-
         public static DisplayItem? GetCurrentDisplayItem(this Window window)
         {
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
@@ -31,16 +16,6 @@ namespace MrCapitalQ.FollowAlong.Core.Display
                 displayArea.OuterBounds,
                 displayArea.WorkArea,
                 displayArea.DisplayId.Value);
-        }
-
-        [ComImport]
-        [Guid("3628E81B-3CAC-4C60-B7F4-23CE0E0C3356")]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        [ComVisible(true)]
-        private interface IGraphicsCaptureItemInterop
-        {
-            nint CreateForWindow([In] nint window, [In] ref Guid iid);
-            nint CreateForMonitor([In] nint monitor, [In] ref Guid iid);
         }
     }
 }

--- a/src/MrCapitalQ.FollowAlong/MrCapitalQ.FollowAlong.csproj
+++ b/src/MrCapitalQ.FollowAlong/MrCapitalQ.FollowAlong.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows10.0.22621.0</TargetFramework>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.20348.0</TargetPlatformMinVersion>
     <RootNamespace>MrCapitalQ.FollowAlong</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/src/MrCapitalQ.FollowAlong/ViewModels/MainViewModel.cs
+++ b/src/MrCapitalQ.FollowAlong/ViewModels/MainViewModel.cs
@@ -9,6 +9,7 @@ using MrCapitalQ.FollowAlong.Messages;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Windows.Graphics.Capture;
 
 namespace MrCapitalQ.FollowAlong.ViewModels
 {
@@ -58,7 +59,10 @@ namespace MrCapitalQ.FollowAlong.ViewModels
             if (_captureService.IsStarted || SelectedDisplay is null)
                 return;
 
-            var captureItem = SelectedDisplay.DisplayItem.CreateCaptureItem();
+            var captureItem = GraphicsCaptureItem.TryCreateFromDisplayId(new(SelectedDisplay.DisplayItem.DisplayId));
+            if (captureItem is null)
+                return;
+
             _captureService.StartCapture(new DisplayCaptureItem(captureItem, SelectedDisplay.DisplayItem.OuterBounds.ToRect()));
             WeakReferenceMessenger.Default.Send(new ZoomChanged(Zoom));
             ShowSessionControls = true;


### PR DESCRIPTION
Switch from custom code that was using interops to call CreateForMonitor to the provided WinRT GraphicsCaptureItem.TryCreateFromDisplayId to reduce maintenance. Also update minimum required Windows version that was always required to create GraphicsCaptureItems in this way.