### PR TITLE
Limit frame rate to match tracking rate.

### DIFF
--- a/src/MrCapitalQ.FollowAlong.Core/Capture/FrameArrivedEventArgs.cs
+++ b/src/MrCapitalQ.FollowAlong.Core/Capture/FrameArrivedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Graphics.Canvas;
+using System;
+
+namespace MrCapitalQ.FollowAlong.Core.Capture
+{
+    public class FrameArrivedEventArgs : EventArgs
+    {
+        public FrameArrivedEventArgs(CanvasBitmap bitmap) => Bitmap = bitmap;
+
+        public CanvasBitmap Bitmap { get; }
+    }
+}

--- a/src/MrCapitalQ.FollowAlong.Core/Tracking/TrackingTransformService.cs
+++ b/src/MrCapitalQ.FollowAlong.Core/Tracking/TrackingTransformService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MrCapitalQ.FollowAlong.Core.Utils;
+using System;
 using System.Numerics;
 using Windows.Foundation;
 

--- a/src/MrCapitalQ.FollowAlong.Core/Utils/IUpdateSynchronizer.cs
+++ b/src/MrCapitalQ.FollowAlong.Core/Utils/IUpdateSynchronizer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace MrCapitalQ.FollowAlong.Core.Tracking
+namespace MrCapitalQ.FollowAlong.Core.Utils
 {
     public interface IUpdateSynchronizer
     {

--- a/src/MrCapitalQ.FollowAlong/Program.cs
+++ b/src/MrCapitalQ.FollowAlong/Program.cs
@@ -6,6 +6,7 @@ using MrCapitalQ.FollowAlong.Core.Capture;
 using MrCapitalQ.FollowAlong.Core.Display;
 using MrCapitalQ.FollowAlong.Core.HotKeys;
 using MrCapitalQ.FollowAlong.Core.Tracking;
+using MrCapitalQ.FollowAlong.Core.Utils;
 using MrCapitalQ.FollowAlong.Pages;
 using MrCapitalQ.FollowAlong.Services;
 using MrCapitalQ.FollowAlong.ViewModels;

--- a/src/MrCapitalQ.FollowAlong/Services/UpdateSynchronizer.cs
+++ b/src/MrCapitalQ.FollowAlong/Services/UpdateSynchronizer.cs
@@ -1,4 +1,4 @@
-﻿using MrCapitalQ.FollowAlong.Core.Tracking;
+﻿using MrCapitalQ.FollowAlong.Core.Utils;
 using System;
 using System.Timers;
 

--- a/test/MrCapitalQ.FollowAlong.Core.Tests/Tracking/TrackingTransformServiceTests.cs
+++ b/test/MrCapitalQ.FollowAlong.Core.Tests/Tracking/TrackingTransformServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿using MrCapitalQ.FollowAlong.Core.Tracking;
+using MrCapitalQ.FollowAlong.Core.Utils;
 using NSubstitute;
 using System.Numerics;
 using Windows.Foundation;


### PR DESCRIPTION
Limit the rate that frames are captured from the screen to reduce processing power. It now roughly matches the tracking transform update rate with a default of 60 times a second.