### PR TITLE
Add tests for DisplayViewModel.

### DIFF
--- a/MrCapitalQ.FollowAlong.sln
+++ b/MrCapitalQ.FollowAlong.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{06775EB5-A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MrCapitalQ.FollowAlong.Core.Tests", "test\MrCapitalQ.FollowAlong.Core.Tests\MrCapitalQ.FollowAlong.Core.Tests.csproj", "{D4A1EA3F-1BA0-41CE-930A-1DA2FD5F6762}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MrCapitalQ.FollowAlong.Tests", "test\MrCapitalQ.FollowAlong.Tests\MrCapitalQ.FollowAlong.Tests.csproj", "{9129E1C3-9286-4E21-90C8-4BDB14CB9972}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -65,6 +67,18 @@ Global
 		{D4A1EA3F-1BA0-41CE-930A-1DA2FD5F6762}.Release|x64.Build.0 = Release|x64
 		{D4A1EA3F-1BA0-41CE-930A-1DA2FD5F6762}.Release|x86.ActiveCfg = Release|x86
 		{D4A1EA3F-1BA0-41CE-930A-1DA2FD5F6762}.Release|x86.Build.0 = Release|x86
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Debug|ARM64.Build.0 = Debug|ARM64
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Debug|x64.ActiveCfg = Debug|x64
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Debug|x64.Build.0 = Debug|x64
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Debug|x86.ActiveCfg = Debug|x86
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Debug|x86.Build.0 = Debug|x86
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Release|ARM64.ActiveCfg = Release|ARM64
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Release|ARM64.Build.0 = Release|ARM64
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Release|x64.ActiveCfg = Release|x64
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Release|x64.Build.0 = Release|x64
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Release|x86.ActiveCfg = Release|x86
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -73,6 +87,7 @@ Global
 		{3EAB4E43-2AA6-404B-B57A-E5299D63F09C} = {D6571453-2B25-4051-9FAB-AA815635D7BF}
 		{E68D2B6A-F6CC-467D-AD10-DE887F559C04} = {D6571453-2B25-4051-9FAB-AA815635D7BF}
 		{D4A1EA3F-1BA0-41CE-930A-1DA2FD5F6762} = {06775EB5-A7A8-469B-8474-5528DF049C7E}
+		{9129E1C3-9286-4E21-90C8-4BDB14CB9972} = {06775EB5-A7A8-469B-8474-5528DF049C7E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F538046C-7452-41FE-B085-C328F3C5B786}

--- a/scripts/runTests.ps1
+++ b/scripts/runTests.ps1
@@ -8,7 +8,11 @@ try {
     Get-ChildItem -Path . -Recurse | Where-Object { $_.Name -ilike "TestResults" } | Remove-Item -Force -Recurse
 
     # EnableMsixTooling MSBuild property is needed to build tests from dotnet CLI
-    dotnet test --collect:"XPlat Code Coverage" /p:EnableMsixTooling=true /p:Platform=x64
+    dotnet test `
+        --collect:"XPlat Code Coverage" `
+        /p:EnableMsixTooling=true `
+        /p:Platform=x64 `
+        -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile="**/*.g.cs,**/*.g.i.cs"
     if (!$?) { Exit $LASTEXITCODE }
 
     reportgenerator -reports:"./test/**/coverage.cobertura.xml" -targetdir:"./TestResults/CoverageReport" -reporttypes:Html

--- a/src/MrCapitalQ.FollowAlong/Converters/StreamToImageConverter.cs
+++ b/src/MrCapitalQ.FollowAlong/Converters/StreamToImageConverter.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media.Imaging;
+using System;
+using System.IO;
+
+namespace MrCapitalQ.FollowAlong.Converters
+{
+    internal class StreamToImageConverter : IValueConverter
+    {
+        public object? Convert(object value, Type targetType, object parameter, string language)
+        {
+            if (value is not Stream stream)
+                return null;
+
+            var image = new BitmapImage();
+            image.SetSource(stream.AsRandomAccessStream());
+
+            return image;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/MrCapitalQ.FollowAlong/MrCapitalQ.FollowAlong.csproj
+++ b/src/MrCapitalQ.FollowAlong/MrCapitalQ.FollowAlong.csproj
@@ -33,6 +33,10 @@
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="MrCapitalQ.FollowAlong.Tests" />
+  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\MrCapitalQ.FollowAlong.Core\MrCapitalQ.FollowAlong.Core.csproj" />

--- a/src/MrCapitalQ.FollowAlong/Pages/MainPage.xaml
+++ b/src/MrCapitalQ.FollowAlong/Pages/MainPage.xaml
@@ -15,6 +15,7 @@
       mc:Ignorable="d">
     <Page.Resources>
         <converters:AspectRatioConverter x:Key="AspectRatioConverter" />
+        <converters:StreamToImageConverter x:Key="StreamToImageConverter" />
         <toolkitConverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
         <toolkitConverters:StringFormatConverter x:Key="StringFormatConverter" />
     </Page.Resources>
@@ -74,7 +75,7 @@
                                     BorderThickness="4"
                                     CornerRadius="4"
                                     Margin="4">
-                                <Image Source="{x:Bind BitmapImage}"
+                                <Image Source="{x:Bind Thumbnail, Mode=OneWay, Converter={StaticResource StreamToImageConverter}}"
                                        Height="120"
                                        Width="{x:Bind AspectRatio, Converter={StaticResource AspectRatioConverter}, ConverterParameter=120}" />
                             </Border>

--- a/src/MrCapitalQ.FollowAlong/ViewModels/DisplayViewModel.cs
+++ b/src/MrCapitalQ.FollowAlong/ViewModels/DisplayViewModel.cs
@@ -1,33 +1,41 @@
-﻿using Microsoft.UI.Xaml.Media.Imaging;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using MrCapitalQ.FollowAlong.Core.Capture;
 using MrCapitalQ.FollowAlong.Core.Display;
-using System;
 using System.IO;
 using System.Threading.Tasks;
 
 namespace MrCapitalQ.FollowAlong.ViewModels
 {
-    internal class DisplayViewModel
+    internal class DisplayViewModel : ObservableObject
     {
         private readonly IScreenshotService _screenshotService;
+
+        public Stream? _thumbnail;
 
         public DisplayViewModel(DisplayItem displayItem, IScreenshotService screenshotService)
         {
             DisplayItem = displayItem;
             _screenshotService = screenshotService;
-            BitmapImage = new();
 
             _ = LoadThumbnailAsync();
         }
 
         public DisplayItem DisplayItem { get; }
-        public BitmapImage BitmapImage { get; }
+
+        public Stream? Thumbnail
+        {
+            get => _thumbnail;
+            private set
+            {
+                _thumbnail?.Dispose();
+                _thumbnail = value;
+                OnPropertyChanged(nameof(Thumbnail));
+            }
+        }
+
         public double AspectRatio => (double)DisplayItem.OuterBounds.Width / DisplayItem.OuterBounds.Height;
 
         public async Task LoadThumbnailAsync()
-        {
-            using var memoryStream = await _screenshotService.GetDisplayImageAsync(DisplayItem);
-            await BitmapImage.SetSourceAsync(memoryStream.AsRandomAccessStream());
-        }
+            => Thumbnail = await _screenshotService.GetDisplayImageAsync(DisplayItem);
     }
 }

--- a/test/MrCapitalQ.FollowAlong.Core.Tests/Capture/ScreenshotServiceTests.cs
+++ b/test/MrCapitalQ.FollowAlong.Core.Tests/Capture/ScreenshotServiceTests.cs
@@ -31,8 +31,8 @@ namespace MrCapitalQ.FollowAlong.Core.Tests.Capture
 
         private class TestGraphics : IGraphics
         {
-            private Image _image;
-            private Graphics _graphics;
+            private readonly Image _image;
+            private readonly Graphics _graphics;
 
             public TestGraphics(Image image)
             {

--- a/test/MrCapitalQ.FollowAlong.Tests/MrCapitalQ.FollowAlong.Tests.csproj
+++ b/test/MrCapitalQ.FollowAlong.Tests/MrCapitalQ.FollowAlong.Tests.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\MrCapitalQ.FollowAlong.Core\MrCapitalQ.FollowAlong.Core.csproj" />
+    <ProjectReference Include="..\..\src\MrCapitalQ.FollowAlong\MrCapitalQ.FollowAlong.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MrCapitalQ.FollowAlong.Tests/ViewModels/DisplayViewModelTests.cs
+++ b/test/MrCapitalQ.FollowAlong.Tests/ViewModels/DisplayViewModelTests.cs
@@ -1,0 +1,42 @@
+using MrCapitalQ.FollowAlong.Core.Capture;
+using MrCapitalQ.FollowAlong.Core.Display;
+using MrCapitalQ.FollowAlong.ViewModels;
+using NSubstitute;
+
+namespace MrCapitalQ.FollowAlong.Tests.ViewModels
+{
+    public class DisplayViewModelTests
+    {
+        [Fact]
+        public void Ctor_SetsProperties()
+        {
+            var displayItem = new DisplayItem(true, new(0, 0, 10, 5), new(), 1); ;
+            var stream = new MemoryStream([0x01, 0x02, 0x03]);
+            var screenshotService = Substitute.For<IScreenshotService>();
+            screenshotService.GetDisplayImageAsync(displayItem).Returns(stream);
+
+            var vm = new DisplayViewModel(displayItem, screenshotService);
+
+            Assert.Equal(stream, vm.Thumbnail);
+            Assert.Equal(displayItem.OuterBounds.Width / displayItem.OuterBounds.Height, vm.AspectRatio);
+            screenshotService.Received(1).GetDisplayImageAsync(displayItem);
+        }
+
+        [Fact]
+        public async Task LoadThumbnailAsync_DisposesExistingThumbnailStream()
+        {
+            var displayItem = new DisplayItem(true, new(), new(), 1); ;
+            var stream1 = Substitute.For<Stream>();
+            var stream2 = Substitute.For<Stream>();
+            var screenshotService = Substitute.For<IScreenshotService>();
+            screenshotService.GetDisplayImageAsync(displayItem).Returns(stream1, stream2);
+            var vm = new DisplayViewModel(displayItem, screenshotService);
+
+            await vm.LoadThumbnailAsync();
+
+            Assert.Equal(stream2, vm.Thumbnail);
+            await screenshotService.Received(2).GetDisplayImageAsync(displayItem);
+            stream1.Received(1).Dispose();
+        }
+    }
+}


### PR DESCRIPTION
- Remove direct reference to BitmapImage in DisplayViewModel that prevented unit testing.
- Add unit tests for DisplayViewModel.
- Update runTests script to ignore generated files from code coverage collection.