### PR TITLE
Update readme for new building prerequisites.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,8 @@ Follow Along is an open source app for Windows that makes it easier when screen 
 ## Building
 ### Prerequisites
 - Visual Studio 2022
-  - .NET desktop development workload
+  - Windows application development workload
+  - Windows 11 SDK (10.0.22621.0)
 - .NET 8 SDK
 
 ### Build and Run


### PR DESCRIPTION
- Update building prerequisites for new requirement on Windows 11 SDK.
- Rename .NET desktop development workload to Windows application development workload to match VS's latest update.